### PR TITLE
feat: Add GitHub Actions workflow for project board sync

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,0 +1,31 @@
+name: Sync with Project Board
+on:
+  # Triggers
+  issues:
+    types: [opened, edited, labeled, assigned]
+  pull_request:
+    types: [opened, closed, reopened, labeled]
+
+jobs:
+  sync-to-project:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Add issues to project
+        if: github.event_name == 'issues'
+        uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: "https://github.com/alagaddonjuan/deptportal" # Replace with your project URL
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          labeled: ""
+          
+      - name: Sync PR status
+        if: github.event_name == 'pull_request'
+        uses: srggrs/auto-sync-project@v1.0.1
+        with:
+          project-url: "https://github.com/alagaddonjuan/deptportal"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          column-name: "In Review" # Moves PRs here when opened
+          done-column: "Done" # Moves here when PR is merged


### PR DESCRIPTION
## Purpose
Automatically syncs issues/PRs with the project board:
- Adds new issues to "To Do"
- Moves PRs to "In Review" when opened
- Moves to "Done" when merged

## Testing
1. Create a test issue after merge
2. Verify it appears in project board